### PR TITLE
Eliminate some unnecessary memory operations

### DIFF
--- a/lib/mpi/QMP_comm_mpi.c
+++ b/lib/mpi/QMP_comm_mpi.c
@@ -152,17 +152,9 @@ QMP_comm_sum_float_array_mpi(QMP_comm_t comm, float value[], int count)
   QMP_status_t status = QMP_SUCCESS;
   ENTER;
 
-  float *dest;
-  QMP_alloc(dest, float, count);
-  int err = MPI_Allreduce((void *)value, (void *)dest, count,
+  int err = MPI_Allreduce(MPI_IN_PLACE, (void *)value, count,
 			  MPI_FLOAT, MPI_SUM, comm->mpicomm);
   if(err != MPI_SUCCESS) status = err;
-  else {
-    int i;
-    for (i = 0; i < count; i++)
-      value[i] = dest[i];
-  }
-  QMP_free(dest);
   
   LEAVE;
   return status;
@@ -175,17 +167,9 @@ QMP_comm_sum_double_array_mpi(QMP_comm_t comm, double value[], int count)
   QMP_status_t status = QMP_SUCCESS;
   ENTER;
 
-  double *dest;
-  QMP_alloc(dest, double, count);
-  int err = MPI_Allreduce((void *)value, (void *)dest, count,
+  int err = MPI_Allreduce(MPI_IN_PLACE,(void *)value, count,
 			  MPI_DOUBLE, MPI_SUM, comm->mpicomm);
   if(err != MPI_SUCCESS) status = err;
-  else {
-    int i;
-    for (i = 0; i < count; i++)
-      value[i] = dest[i];
-  }
-  QMP_free(dest);
   
   LEAVE;
   return status;

--- a/lib/mpi/QMP_init_mpi.c
+++ b/lib/mpi/QMP_init_mpi.c
@@ -32,8 +32,14 @@ QMP_init_machine_mpi (int* argc, char*** argv, QMP_thread_level_t required,
     break;
   }
 
-  if (MPI_Init_thread(argc, argv, mpi_req, &mpi_prv) != MPI_SUCCESS) 
-    QMP_abort_string (-1, "MPI_Init failed");
+  int flag;
+  MPI_Initialized(&flag); // needed to coexist with other libs apparently
+    if ( !flag ) {
+      if (MPI_Init_thread(argc, argv, mpi_req, &mpi_prv) != MPI_SUCCESS) 
+	QMP_abort_string (-1, "MPI_Init failed");
+    }else{
+      MPI_Query_thread(&mpi_prv);
+    }
 
   switch(mpi_prv) { 
   case MPI_THREAD_SINGLE:


### PR DESCRIPTION
The MPI_IN_PLACE option uses one buffer for send and receive and is intended to eliminate unnecessary memory operations of the exact sort seen here.  I first learned of this when I saw it used in Grid for global sums.  There are, in principle, other portions of qmp which could benefit from this, but these are the only ones I've edited at the moment due to not having test code for the other functions.  I've done a consistency check on my laptop, and I intend to test at scale soon to confirm the speed up.  If there's a reason why this method is not preferred for qmp, I'd be interested to hear it.  Thanks.