### PR TITLE
Check for MPI_Finalize

### DIFF
--- a/lib/mpi/QMP_init_mpi.c
+++ b/lib/mpi/QMP_init_mpi.c
@@ -93,7 +93,12 @@ QMP_init_machine_mpi (int* argc, char*** argv, QMP_thread_level_t required,
 void
 QMP_finalize_msg_passing_mpi (void)
 {
-  MPI_Finalize();
+  int flag;
+  MPI_Finalized(&flag);
+
+  if (!flag) {
+    MPI_Finalize();
+  }
 }
 
 


### PR DESCRIPTION
You check for `MPI_Initialized` before you run `MPI_Initialize`, which is good, but for some reason you do not check for `MPI_Finalized` before running `MPI_Finalize`.