### PR TITLE
allow user to control logic layout qmp args

### DIFF
--- a/lib/QMP_topology.c
+++ b/lib/QMP_topology.c
@@ -144,7 +144,7 @@ QMP_declare_logical_topology (const int* dims, int ndim)
 {
   QMP_status_t r;
   ENTER;
-  r = QMP_comm_declare_logical_topology_map (QMP_comm_get_default(), dims, ndim, NULL, 0);
+  r = QMP_comm_declare_logical_topology_map (QMP_comm_get_default(), dims, ndim, QMP_args->lmap, QMP_args->lmaplen);
   LEAVE;
   return r;
 }


### PR DESCRIPTION
Per James Osborn's instructions, in QMP_topology.c, in QMP_declare_logical_topology(), L147, r = QMP_comm_declare_logical_topology_map(), change the last two arguments from "NULL,0" to "QMP_args->lmap, QMP_args->lmaplen".  This allows the user to control the inter vs intra node layout, for example, with 
 -qmp-alloc-map 3 2 1 0 -qmp-logic-map  3 2 1 0
passed at run time.  Verified with Chroma.