### PR TITLE
Feature/cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,17 +94,13 @@ if( NOT ${QMP_TESTING})
  set(BUILD_TESTING OFF)
 endif()
 
-#install the  source headers                    
-install(DIRECTORY include DESTINATION . )
 
  
 # Configuration file
 configure_file(include/qmp_config.h.cmake.in  include/qmp_config.h)
-#install the generated headers
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/qmp_config.h DESTINATION include)
-
 configure_file(bin/qmp-config.cmake.in  bin/qmp-config @ONLY)
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/qmp-config DESTINATION bin)
+
+
 
 
 
@@ -116,3 +112,33 @@ endif(BUILD_TESTING)
 if( QMP_BUILD_DOCS ) 
   add_subdirectory(doc)
 endif()        
+
+# Installs the targers (The QMP Library)
+# into the 'QMPTargets' export pack
+
+
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/qmp-config DESTINATION bin)
+
+install(TARGETS qmp EXPORT QMPTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY  DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include)
+
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+	  
+
+# Install the QMPTargets  into the lib/cmake/QMP directory
+install(EXPORT QMPTargets NAMESPACE QMP:: DESTINATION lib/cmake/QMP)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    QMPVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY AnyNewerVersion
+    )
+
+# Using this macro we can pass some path vars down...
+# But we are not doing this for now.
+configure_package_config_file(QMPConfig.cmake.in QMPConfig.cmake INSTALL_DESTINATION lib/cmake/QMP)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QMPVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/QMPConfig.cmake DESTINATION lib/cmake/QMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,3 +142,4 @@ write_basic_package_version_file(
 # But we are not doing this for now.
 configure_package_config_file(QMPConfig.cmake.in QMPConfig.cmake INSTALL_DESTINATION lib/cmake/QMP)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QMPVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/QMPConfig.cmake DESTINATION lib/cmake/QMP)
+export(PACKAGE QMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.11)
 project(QMP VERSION 2.5.1)
 
-# Boiler plate
+# Boiler plate -- install directories
 include(GNUInstallDirs)
+
+# Boiler plate -- CTest
+include(CTest)
 
 #Options
 # --enable-extra-debugging 
@@ -28,6 +31,9 @@ option(QMP_BGQ "Enable BlueGene/Q Personality to set native machine geometry" OF
 # --enable-bgspi
 option(QMP_BGSPI "Enable BlueGene SPI" OFF)
 
+# --enable-testing
+option(QMP_TESTING "Enable buidling of the examples" OFF)
+
 # Configuration file
 configure_file(include/qmp_config.h.cmake.in 
                       include/qmp_config.h)
@@ -40,12 +46,13 @@ set(QMP_COMMS_LIBS "" CACHE STRING "Any extra comms libs")
 # Use DMalloc
 option(QMP_USE_DMALLOC "Enable DMalloc" OFF)
 
+# Build Docs
+option(QMP_BUILD_DOCS "Enable Building docs with Doxygen" OFF)
 
                       
 
 
-#FIXME: Add doxygen
-# find_package(Doxygen)
+
 
 if(QMP_USE_DMALLOC)
   find_library(DMALLOC_LIBRARY dmalloc /usr/lib /usr/local/lib)
@@ -83,6 +90,10 @@ if(QMP_BGSPI)
 endif(QMP_BGSPI)
  
 
+if( NOT ${QMP_TESTING})
+ set(BUILD_TESTING OFF)
+endif()
+
 #install the  source headers                    
 install(DIRECTORY include DESTINATION . )
 
@@ -98,4 +109,10 @@ install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/qmp-config DESTINATION bin)
 
 
 add_subdirectory(lib)            
-                   
+if( BUILD_TESTING ) 
+  add_subdirectory(examples)
+endif(BUILD_TESTING)
+
+if( QMP_BUILD_DOCS ) 
+  add_subdirectory(doc)
+endif()        

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 	  
 
 # Install the QMPTargets  into the lib/cmake/QMP directory
-install(EXPORT QMPTargets NAMESPACE QMP:: DESTINATION lib/cmake/QMP)
+install(EXPORT QMPTargets DESTINATION lib/cmake/QMP)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
@@ -142,4 +142,3 @@ write_basic_package_version_file(
 # But we are not doing this for now.
 configure_package_config_file(QMPConfig.cmake.in QMPConfig.cmake INSTALL_DESTINATION lib/cmake/QMP)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QMPVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/QMPConfig.cmake DESTINATION lib/cmake/QMP)
-export(PACKAGE QMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,101 @@
+cmake_minimum_required(VERSION 3.11)
+project(QMP VERSION 2.5.1)
+
+# Boiler plate
+include(GNUInstallDirs)
+
+#Options
+# --enable-extra-debugging 
+# This is a boolean so use option
+option(QMP_EXTRA_DEBUG "Enable extra debugging" OFF)
+
+# --enable-profiling
+option(QMP_PROFILING "Enable Profiling" OFF)
+
+# --enabe-timing
+option(QMP_TIMING "Enable Timing" OFF)
+
+# Change MPI build to Boolean
+# If true use MPI
+# if false do single
+option(QMP_MPI "Enable MPI" OFF)
+
+# Deprecating BGL and BGP personalities
+
+# --enable-bgq
+option(QMP_BGQ "Enable BlueGene/Q Personality to set native machine geometry" OFF)
+
+# --enable-bgspi
+option(QMP_BGSPI "Enable BlueGene SPI" OFF)
+
+# Configuration file
+configure_file(include/qmp_config.h.cmake.in 
+                      include/qmp_config.h)
+                      
+              
+set(QMP_COMMS_CFLAGS "" CACHE STRING "Any extra comms flags")
+set(QMP_COMMS_LDFLAGS "" CACHE STRING "Any extra comms LDFLAGS")
+set(QMP_COMMS_LIBS "" CACHE STRING "Any extra comms libs")
+
+# Use DMalloc
+option(QMP_USE_DMALLOC "Enable DMalloc" OFF)
+
+
+                      
+
+
+#FIXME: Add doxygen
+# find_package(Doxygen)
+
+if(QMP_USE_DMALLOC)
+  find_library(DMALLOC_LIBRARY dmalloc /usr/lib /usr/local/lib)
+  find_path(DMALLOC_INCLUDE_DIR dmalloc.h PATHS /usr/include /usr/local/include)
+endif(QMP_USE_DMALLOC)   
+
+
+set(QMP_COMMS_TYPE "single")
+
+if(QMP_MPI) 
+  find_package(MPI REQUIRED)
+   set(HAVE_MPI 1)
+   set(QMP_COMMS_TYPE "MPI")
+endif(QMP_MPI)
+
+if(QMP_EXTRA_DEBUG)
+  set(_QMP_DEBUG 1)
+  set(_QMP_TRACE 1)
+endif(QMP_EXTRA_DEBUG)
+
+if(QMP_PROFILING)
+  set(QMP_BUILD_PROFILING 1)
+endif(QMP_PROFILING)  
+
+if(QMP_TIMING)
+  set(QMP_BUILD_TIMING 1)
+endif(QMP_TIMING)
+
+if(QMP_BGQ)
+  set(HAVE_BGQ 1)
+endif(QMP_BGQ)
+
+if(QMP_BGSPI)
+ set(HAVE_BGSPI 1)
+endif(QMP_BGSPI)
+ 
+
+#install the  source headers                    
+install(DIRECTORY include DESTINATION . )
+
+ 
+# Configuration file
+configure_file(include/qmp_config.h.cmake.in  include/qmp_config.h)
+#install the generated headers
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/qmp_config.h DESTINATION include)
+
+configure_file(bin/qmp-config.cmake.in  bin/qmp-config @ONLY)
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/qmp-config DESTINATION bin)
+
+
+
+add_subdirectory(lib)            
+                   

--- a/QMPConfig.cmake.in
+++ b/QMPConfig.cmake.in
@@ -1,3 +1,5 @@
+@PACKAGE_INIT@
+
 # Boiler Plate Config file
 #
 #
@@ -8,7 +10,7 @@ set(QMP_MPI @QMP_MPI@)
 
 # If we are using MPI find the dependency
 if(QMP_MPI)
-  find_dependency(MPI::C REQUIRED)
+  find_dependency(MPI REQUIRED)
 endif()
 
 # Include the generated exported targets

--- a/QMPConfig.cmake.in
+++ b/QMPConfig.cmake.in
@@ -1,0 +1,15 @@
+# Boiler Plate Config file
+#
+#
+include(CMakeFindDependencyMacro)
+
+# Capture if we are using MPI or not
+set(QMP_MPI @QMP_MPI@)
+
+# If we are using MPI find the dependency
+if(QMP_MPI)
+  find_dependency(MPI::C REQUIRED)
+endif()
+
+# Include the generated exported targets
+include(${CMAKE_CURRENT_LIST_DIR}/QMPTargets.cmake)

--- a/bin/qmp-config.cmake.in
+++ b/bin/qmp-config.cmake.in
@@ -1,0 +1,174 @@
+#!/bin/sh
+
+# qmp-config
+#
+# George T. Fleming, 11 February 2003
+#
+# Tool for retrieving configuration information about the installed version
+# of QMP.
+#
+# This script was inspired by many similar scripts available in RedHat Linux,
+# including gnome-config, gtk-config and xmms-config.
+
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix_set=no
+
+version="@PROJECT_VERSION@"
+
+qmp_comms_type="@QMP_COMMS_TYPE@"
+qmp_cc="@CMAKE_C_COMPILER@"
+qmp_copts="@CMAKE_C_FLAGS@"
+qmp_cflags="-I@CMAKE_INSTALL_PREFIX@/include @QMP_COMMS_CFLAGS@ @CMAKE_C_COMPILER_FLAGS@"
+qmp_ldflags="-L@CMAKE_INSTALL_PREFIX@/lib @QMP_COMMS_LDFLAGS@"
+qmp_libs="-lqmp @QMP_COMMS_LIBS@"
+qmp_ranlib="@CMAKE_C_COMPILER_RANLIB@"
+qmp_ar="@CMAKE_C_COMPILER_AR@"
+
+usage()
+{
+  cat <<EOF
+Usage: qmp-config [OPTIONS]
+Options:
+  [--prefix[=DIR]]
+  [--exec-prefix[=DIR]]
+  [--version]
+  [--comms]
+  [--cc]
+  [--copts]
+  [--cflags]
+  [--ldflags]
+  [--libs]
+  [--ranlib]
+  [--ar]
+EOF
+  exit $1
+}
+
+if test $# -eq 0; then
+  usage 1 1>&2
+fi
+
+while test $# -gt 0; do
+  case "$1" in
+    -*=*) optarg=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
+    *)    optarg= ;;
+  esac
+
+  case $1 in
+    --prefix=*)
+      prefix=$optarg
+      if test $exec_prefix_set = no ; then
+        exec_prefix=$optarg
+      fi
+      ;;
+
+    --prefix)
+      echo_prefix=yes
+      ;;
+
+    --exec-prefix=*)
+      exec_prefix=$optarg
+      exec_prefix_set=yes
+      ;;
+
+    --exec-prefix)
+      echo_exec_prefix=yes
+      ;;
+
+    --version)
+      echo $version
+      ;;
+
+    --comms)
+      echo $qmp_comms_type
+      ;;
+
+    --cc)
+      echo $qmp_cc
+      ;;
+
+    --copts)
+      echo $qmp_copts
+      ;;
+
+    --cflags)
+      echo_cflags=yes
+      ;;
+
+    --ldflags)
+      echo_ldflags=yes
+      ;;
+
+    --libs)
+      echo_libs=yes
+      ;;
+    --ranlib)
+      echo $qmp_ranlib
+      ;;
+    --ar)
+      echo $qmp_ar
+      ;;
+    *)
+      usage 1 1>&2
+      ;;
+
+  esac
+  shift
+done
+
+if test "X${echo_prefix}X" = "XyesX" ; then
+  echo $prefix
+fi
+
+if test "X${echo_exec_prefix}X" = "XyesX" ; then
+  echo $exec_prefix
+fi
+
+if test "X${echo_cflags}X" = "XyesX" ; then
+  output_cflags=
+  for i in $qmp_cflags ; do
+    case $i in
+      -I/usr/include) ;;
+      -g) ;;
+      -O*) ;;
+      -W*) ;;
+      *)
+        case " $output_cflags " in
+          *\ $i\ *) ;;                             # already there, skip it
+          *) output_cflags="$output_cflags $i"     # add it to output
+        esac
+    esac
+  done
+  echo $output_cflags
+fi
+
+if test "X${echo_ldflags}X" = "XyesX" ; then
+  output_ldflags=
+  for i in $qmp_ldflags ; do
+    if test "X${i}X" != "X-I/usr/libX" ; then
+      case " $output_ldflags " in
+        *\ $i\ *) ;;                                # already here skip it
+        *) output_ldflags="$output_ldflags $i"     # add it to output
+      esac
+    fi
+  done
+  echo $output_ldflags
+fi
+
+# Straight out any possible duplicates, but be careful to
+# get `-lfoo -lbar -lbaz' for `-lfoo -lbaz -lbar -lbaz'
+
+if test "X${echo_libs}X" = "XyesX" ; then
+  rev_libs=
+  for i in $qmp_libs ; do
+    rev_libs="$i $rev_libs"
+  done
+  output_libs=
+  for i in $rev_libs ; do
+    case " $output_libs " in
+      *) output_libs="$i $output_libs" ;;  # add it to output in reverse order
+    esac
+  done
+  echo $output_libs
+fi

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,26 @@
+  # set input and output files
+ find_package(Doxygen)
+ if( DOXYGEN_FOUND ) 
+ 
+    # You can leave CMakeVariable substitutions etc in the QMPdoxyfile
+    set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/QMPdoxyfile)
+    
+    # This creates a doxyfile with CMake @vars substituted
+    set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/QMPdoxyfile)
+    configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+    
+    
+    message("Doxygen build started")
+    # Build the doxygen with custom target
+    # note the option ALL which allows to build the docs together with the application
+    add_custom_target( doc_doxygen ALL
+        COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Generating API documentation with Doxygen"
+        VERBATIM )
+        
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/oxydocs DESTINATION doc)
+    
+else (DOXYGEN_FOUND)
+    message("Doxygen need to be installed to generate the doxygen documentation")
+endif (DOXYGEN_FOUND)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,18 @@
+foreach(prog QMP_test 
+                      QMP_msg
+                      QMP_grid_test
+                      QMP_loopback
+                      QMP_qcd_test
+                      QMP_stride_test
+                      QMP_perf
+                      QMP_broadcast
+                      QMP_gcomm_perf
+                      QMP_MILC_test
+                      QMP_show_geom)
+
+add_executable(${prog} "${prog}.c"  )
+target_link_libraries(${prog} qmp m)
+set_target_properties(qmp PROPERTIES C_STANDARD 99)
+set_target_properties(qmp PROPERTIES C_EXTENSIONS OFF)
+
+endforeach()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,7 +12,8 @@ foreach(prog QMP_test
 
 add_executable(${prog} "${prog}.c"  )
 target_link_libraries(${prog} qmp m)
-set_target_properties(qmp PROPERTIES C_STANDARD 99)
-set_target_properties(qmp PROPERTIES C_EXTENSIONS OFF)
+set_target_properties(${prog} PROPERTIES C_STANDARD 99)
+set_target_properties(${prog} PROPERTIES C_EXTENSIONS OFF)
+install(TARGETS ${prog} DESTINATION examples )
 
 endforeach()

--- a/include/qmp_config.h.cmake.in
+++ b/include/qmp_config.h.cmake.in
@@ -1,0 +1,26 @@
+/* compiling for BG/Q */
+#cmakedefine HAVE_BGQ
+
+/* compiling for SPI */
+#cmakedefine HAVE_BGSPI
+
+/* compiling for MPI */
+#cmakedefine HAVE_MPI
+
+/* build QMP to allow profiling */
+#cmakedefine QMP_BUILD_PROFILING
+
+/* build QMP with function timing */
+#cmakedefine QMP_BUILD_TIMING
+
+/* Define if using the dmalloc debugging malloc package */
+#cmakedefine WITH_DMALLOC
+
+/* enable extra debugging */
+#cmakedefine _QMP_DEBUG
+
+/* enable extra tracing */
+#cmakedefine _QMP_TRACE
+
+/* Version string */
+#define VERSION "@CMAKE_PROJECT_VERSION@"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -33,8 +33,12 @@ endif( QMP_BGSPI)
 # define target
 add_library(qmp ${QMP_SRC})
 
+
+	
 set_target_properties(qmp PROPERTIES C_STANDARD 99)
 set_target_properties(qmp PROPERTIES C_EXTENSIONS OFF)
+
+
 # Configure the target
 # Includes from source
 target_include_directories(qmp PUBLIC
@@ -50,13 +54,3 @@ target_include_directories(qmp PUBLIC
 if( QMP_MPI )
   target_link_libraries(qmp PUBLIC MPI::MPI_C)
 endif(QMP_MPI) 
-
-install(TARGETS qmp EXPORT QMPConfig
-  ARCHIVE DESTINATION lib
-  LIBRARY  DESTINATION lib
-  RUNTIME DESTINATION lib)
-  
-
-
-install(EXPORT QMPConfig DESTINATION cmake)
-export(TARGETS qmp FILE QMPConfig.cmake )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,62 @@
+set(QMP_SRC
+   QMP_comm.c
+   QMP_error.c
+   QMP_grid.c
+   QMP_init.c
+   QMP_machine.c
+   QMP_mem.c
+   QMP_split.c
+   QMP_topology.c
+   QMP_util.c)
+   
+
+if( QMP_MPI )    
+  list(APPEND QMP_SRC
+    mpi/QMP_comm_mpi.c
+    mpi/QMP_error_mpi.c
+    mpi/QMP_init_mpi.c
+    mpi/QMP_mem_mpi.c
+    mpi/QMP_split_mpi.c
+    mpi/QMP_topology_mpi.c)
+endif( QMP_MPI)
+   
+   
+#BGSPI Soures
+if( QMP_BGSPI ) 
+ list(APPEND QMP_SRC
+    bgspi/QMP_comm_bgspi.c
+    bgspi/QMP_init_bgspi.c
+    bgspi/QMP_mem_bgspi.c
+    bgspi/qspi.c)
+endif( QMP_BGSPI) 
+
+# define target
+add_library(qmp ${QMP_SRC})
+
+set_target_properties(qmp PROPERTIES C_STANDARD 99)
+set_target_properties(qmp PROPERTIES C_EXTENSIONS OFF)
+# Configure the target
+# Includes from source
+target_include_directories(qmp PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  $<INSTALL_INTERFACE:include>)
+
+# generated includes
+target_include_directories(qmp PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
+  $<INSTALL_INTERFACE:include>)
+  
+# Use the MPI Library 
+if( QMP_MPI )
+  target_link_libraries(qmp PUBLIC MPI::MPI_C)
+endif(QMP_MPI) 
+
+install(TARGETS qmp EXPORT QMPConfig
+  ARCHIVE DESTINATION lib
+  LIBRARY  DESTINATION lib
+  RUNTIME DESTINATION lib)
+  
+
+
+install(EXPORT QMPConfig DESTINATION cmake)
+export(TARGETS qmp FILE QMPConfig.cmake )


### PR DESCRIPTION
Added basic CMake structure. E.g. one can now configure from a parallel build directory with:

```cmake ../qmp -DQMP_MPI=ON -DCMAKE_C_COMPILER=mpicc -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/home/bjoo/installtest_mpi -DQMP_TESTING=ON -DQMP_BUILD_DOCS=ON```

-DQMP_TESTING will cause the executables in examples/ to be build (CTests can be added later)
-DQMP_BUILD_DOCS will cause the docs to be build with doxygen
-DQMP_BGQ and -DQMP_BGSPI are also available. 

Previous BGL and BGP code has not been removed, but I haven't added options to enable them as a step to deprecation.

for a single node build set- -DQMP_MPI=OFF

One can use the CCMake as well to set the cache variables.
The produced qmp-config file is a bit basic  but offers -I -L and -l flags

various CMake Config files should be installed to allow linking the library into other projects.

previous GNU build system functionality should remain unchanged.