### PR TITLE
Eliminated compiler warnings

### DIFF
--- a/examples/QMP_MILC_test.c
+++ b/examples/QMP_MILC_test.c
@@ -49,8 +49,8 @@
 
 struct perf_argv
 {
-  int size;
-  int loops;
+  size_t size;
+  size_t loops;
 };
 
 #define SEND 0
@@ -111,15 +111,15 @@ get_field(char *buf, int size, int fromnode)
 int
 main (int argc, char** argv)
 {
-  int i, j, k;
+  size_t i, j, k;
   QMP_status_t status;
-  int num_nodes;
+  size_t num_nodes;
   struct perf_argv pargv;
   QMP_mem_t  *mem;
-  int   *value;
+  size_t   *value;
   double it, ft, bw;
   int dims[4];
-  int ndims = 4;
+  size_t ndims = 4;
   QMP_thread_level_t req, prv;
   
   req = QMP_THREAD_SINGLE;
@@ -133,7 +133,7 @@ main (int argc, char** argv)
   /* If this is the root node, get dimension information from key board */
   if (QMP_is_primary_node()) {
     QMP_fprintf (stderr, "Enter memory size and number of loops to run\n");
-    if(scanf ("%d %d", &pargv.size, &pargv.loops)!=2)
+    if(scanf ("%zu %zu", &pargv.size, &pargv.loops)!=2)
       QMP_abort_string (-1, "invalid input\n");
   }
 
@@ -166,7 +166,7 @@ main (int argc, char** argv)
   if (QMP_is_primary_node ()) {
     it = get_current_time ();
     for (i = 0; i < pargv.loops; i++) {
-      value = (int *)QMP_get_memory_pointer(mem);
+      value = (size_t *)QMP_get_memory_pointer(mem);
       for (k = 0; k < pargv.size/sizeof(int); k++)
 	value[k] = i;
       for (j = 1; j < num_nodes; j++)
@@ -180,7 +180,7 @@ main (int argc, char** argv)
   else {
     it = get_current_time ();
     for (i = 0; i < pargv.loops; i++) {
-      value = (int *)QMP_get_memory_pointer(mem);
+      value = (size_t *)QMP_get_memory_pointer(mem);
       get_field ((char *)value, pargv.size, 0);
       for (k = 0; k < pargv.size/sizeof(int); k++)
 	if (value[k] != i) 

--- a/examples/QMP_perf.c
+++ b/examples/QMP_perf.c
@@ -245,6 +245,8 @@ test_pingpong_verify (int** smem,
 		      QMP_msghandle_t* recvh,
 		      struct perf_argv* pargv)
 {
+  QMP_UNUSED_PARAM(smem);
+  QMP_UNUSED_PARAM(rmem);
   double it, ft, dt, bwval;
   int    i, j, k;
   QMP_status_t err;
@@ -349,6 +351,8 @@ test_pingpong (int** smem,
 	       struct perf_argv* pargv)
 
 {
+  QMP_UNUSED_PARAM(smem);
+  QMP_UNUSED_PARAM(rmem);
   double it, ft, dt, bwval;
   int    i, j;
   QMP_status_t err;
@@ -446,6 +450,8 @@ test_oneway (int** smem,
 	     QMP_msghandle_t* recvh,
 	     struct perf_argv* pargv)
 {
+  QMP_UNUSED_PARAM(smem);
+  QMP_UNUSED_PARAM(rmem);
   double it, ft, dt, bwval;
   int    i, j;
   QMP_status_t err;
@@ -527,6 +533,8 @@ test_simultaneous_send (int** smem,
 			QMP_msghandle_t* recvh,
 			struct perf_argv* pargv)
 {
+  QMP_UNUSED_PARAM(smem);
+  QMP_UNUSED_PARAM(rmem);
   double it, ft, dt, bwval;
   int    i, j;
   QMP_status_t err;
@@ -867,8 +875,9 @@ main (int argc, char** argv)
     fprintf (stderr, "QMP_init failed\n");
     return -1;
   }
-  if(QMP_get_node_number()==0)
+  if(QMP_get_node_number()==0) {
     printf("finished init\n"); fflush(stdout);
+  }
 
   if (parse_options (argc, argv, &pargv) == -1) {
     if(QMP_get_node_number()==0)
@@ -936,12 +945,15 @@ main (int argc, char** argv)
   recvh = (QMP_msghandle_t *)malloc(nc*sizeof (QMP_msghandle_t));
 
   QMP_barrier();
-  if(QMP_get_node_number()==0) printf("\n"); fflush(stdout);
+  if(QMP_get_node_number()==0) { 
+	  printf("\n"); fflush(stdout);
+  }
   if(pargv.option & TEST_SIMUL) {
     int opts = pargv.option;
     pargv.option = TEST_SIMUL;
-    if(QMP_get_node_number()==0)
+    if(QMP_get_node_number()==0) {
       QMP_printf("starting simultaneous sends"); fflush(stdout);
+    }
     for(i=pargv.minsize; i<=pargv.maxsize; i*=pargv.facsize) {
       pargv.size = i;
       create_msgs(smem, rmem, sendmem, recvmem, sendh, recvh, ndims, nc, i, &pargv);
@@ -949,16 +961,18 @@ main (int argc, char** argv)
       check_mem(rmem, ndims, nc, i);
       free_msgs(smem, rmem, sendmem, recvmem, sendh, recvh, ndims, nc);
     }
-    if(QMP_get_node_number()==0)
+    if(QMP_get_node_number()==0) {
       QMP_printf("finished simultaneous sends\n"); fflush(stdout);
+    }
     pargv.option = opts;
   }
 
   if(pargv.option & TEST_PINGPONG) {
     int opts = pargv.option;
     pargv.option = TEST_PINGPONG;
-    if(QMP_get_node_number()==0)
+    if(QMP_get_node_number()==0) {
       QMP_printf("starting ping pong sends"); fflush(stdout);
+    }
     for(i=pargv.minsize; i<=pargv.maxsize; i*=pargv.facsize) {
       pargv.size = i;
       create_msgs(smem, rmem, sendmem, recvmem, sendh, recvh, ndims, nc, i, &pargv);
@@ -969,16 +983,18 @@ main (int argc, char** argv)
       check_mem(rmem, ndims, nc, i);
       free_msgs(smem, rmem, sendmem, recvmem, sendh, recvh, ndims, nc);
     }
-    if(QMP_get_node_number()==0)
+    if(QMP_get_node_number()==0) {
       QMP_printf("finished ping pong sends\n"); fflush(stdout);
+    }
     pargv.option = opts;
   }
 
   if(pargv.option & TEST_ONEWAY) {
     int opts = pargv.option;
     pargv.option = TEST_ONEWAY;
-    if(QMP_get_node_number()==0)
+    if(QMP_get_node_number()==0) { 
       QMP_printf("starting one way sends"); fflush(stdout);
+    }
     for(i=pargv.minsize; i<=pargv.maxsize; i*=pargv.facsize) {
       pargv.size = i;
       create_msgs(smem, rmem, sendmem, recvmem, sendh, recvh, ndims, nc, i, &pargv);
@@ -986,8 +1002,9 @@ main (int argc, char** argv)
       if(!pargv.sender) check_mem(rmem, ndims, nc, i);
       free_msgs(smem, rmem, sendmem, recvmem, sendh, recvh, ndims, nc);
     }
-    if(QMP_get_node_number()==0)
+    if(QMP_get_node_number()==0) {
       QMP_printf("finished one way sends"); fflush(stdout);
+    }
     pargv.option = opts;
   }
 

--- a/include/QMP_P_COMMON.h
+++ b/include/QMP_P_COMMON.h
@@ -72,7 +72,7 @@ typedef struct QMP_machine
 
   QMP_thread_level_t thread_level;
 } QMP_machine_t;
-#define QMP_MACHINE_INIT 0.0, 0, QMP_SWITCH, NULL, 0, QMP_FALSE, 0, 0, QMP_SUCCESS, QMP_THREAD_SINGLE
+#define QMP_MACHINE_INIT 0.0, 0, QMP_SWITCH, NULL, 0, QMP_FALSE, 0, 0, 0, 0, QMP_SUCCESS, QMP_THREAD_SINGLE
 extern QMP_machine_t *QMP_machine;
 
 /*

--- a/include/qmp.h
+++ b/include/qmp.h
@@ -1155,4 +1155,12 @@ extern int QMP_version_int(void);
 
 #endif
 
+/* 
+ * Mark parameters as unused: that are in the interface but not in the implementation.
+ * Thanks to StackOverflow: https://stackoverflow.com/questions/3599160/how-to-suppress-unused-parameter-warnings-in-c
+ */
+#ifndef QMP_UNUSED_PARAM
+#define QMP_UNUSED_PARAM(param) (void)(param)
+#endif
+
 #endif

--- a/lib/QMP_mem.c
+++ b/lib/QMP_mem.c
@@ -28,6 +28,8 @@ QMP_allocate_memory (size_t nbytes)
 QMP_mem_t *
 QMP_allocate_aligned_memory (size_t nbytes, size_t alignment, int flags)
 {
+  QMP_UNUSED_PARAM(flags);
+
   QMP_mem_t *mem;
   ENTER;
 
@@ -116,7 +118,7 @@ QMP_declare_strided_msgmem (void* base,
   struct QMP_msgmem_struct *mem;
   ENTER;
 
-  if( stride == blksize || nblocks == 1 ) { /* Not really strided */
+  if( (stride >= 0 ) && ((size_t)stride == blksize || nblocks == 1 )) { /* Not really strided */
     mem = QMP_declare_msgmem(base, blksize*nblocks);
   } else { /* Really strided */
     QMP_alloc(mem, struct QMP_msgmem_struct, 1);

--- a/lib/QMP_topology.c
+++ b/lib/QMP_topology.c
@@ -79,6 +79,9 @@ QMP_set_topo(QMP_comm_t comm, const int* dims, int ndim, const int *map, int nma
 static QMP_status_t
 QMP_set_topo_native(QMP_comm_t comm, const int *map, int nmap)
 {
+  QMP_UNUSED_PARAM( comm );
+  QMP_UNUSED_PARAM( map );
+  QMP_UNUSED_PARAM( nmap );
   QMP_status_t status = QMP_SUCCESS;
   ENTER;
 #ifdef QMP_SET_TOPO_NATIVE

--- a/lib/mpi/QMP_comm_mpi.c
+++ b/lib/mpi/QMP_comm_mpi.c
@@ -279,7 +279,10 @@ static int op_inited=0;
  */
 static void
 qmp_bfunc_mpi(void* in, void* inout, int* len, MPI_Datatype* type)
-{
+{ 
+  QMP_UNUSED_PARAM(len);
+  QMP_UNUSED_PARAM(type);
+
   qmp_user_bfunc(inout, in);
 }
 

--- a/lib/mpi/QMP_topology_mpi.c
+++ b/lib/mpi/QMP_topology_mpi.c
@@ -64,6 +64,7 @@ get_rank(const int *x, int *l, int *p, int nd)
 QMP_status_t
 QMP_set_topo_mpi(QMP_comm_t comm)
 {
+  QMP_UNUSED_PARAM(comm);
   //remap_mpi((int *)dims, ndim);
   return QMP_SUCCESS;
 }


### PR DESCRIPTION
I added some patches to eliminate compiler warnings. Most came from unused variables, so I defined a macro to magic those away. Then there were. a bunch of:
```
if( foo ) 
  QMP_printf(...) ; fflush(stdout);
```
which tripped the misleading indentation warning so I changed these up with ` {} ` as 

```
if (foo) { 
 QMP_printf(...) ; fflush(stdout);
}
```

The other things were comparisons between signed and unsigned ints. So I tried to make these work.
Please review and merge.
